### PR TITLE
Copy clBLAS header files upon install

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -34,3 +34,7 @@ install(TARGETS isaac LIBRARY DESTINATION lib ARCHIVE DESTINATION lib)
 set(INSTALL_INCLUDE_DIR /usr/local/include)
 install(DIRECTORY isaac "${PROJECT_SOURCE_DIR}/include/isaac"
            DESTINATION "${INSTALL_INCLUDE_DIR}"  FILES_MATCHING PATTERN "*.h" PATTERN "*.hpp")
+install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/external/"
+           DESTINATION "${INSTALL_INCLUDE_DIR}"
+           FILES_MATCHING PATTERN "clBLAS*.h"
+           PATTERN "cuda" EXCLUDE)


### PR DESCRIPTION
Projects that only depend on the clBLAS routines implemented by
ISAAC do not have any other clBLAS dependency than ISAAC. However, they
need the clBLAS header files installed. This fix makes it so that such
projects only need to install ISAAC.