### PR TITLE
Negative inc of vector && clblasConjTrans supported

### DIFF
--- a/lib/jit/generation/elementwise_2d.cpp
+++ b/lib/jit/generation/elementwise_2d.cpp
@@ -68,6 +68,7 @@ std::string elementwise_2d::generate_impl(std::string const & suffix, expression
   stream << "{" << std::endl;
   stream.inc_tab();
 
+  stream << tools::join(negative_inc_process(device, symbols, tree), "  ") << std::endl;
   element_wise_loop_1D(stream, 1, "i", "M", "$GLOBAL_IDX_0", "$GLOBAL_SIZE_0", [&](unsigned int){
     element_wise_loop_1D(stream, 1, "j", "N", "$GLOBAL_IDX_1", "$GLOBAL_SIZE_1", [&](unsigned int){
       //Declares register to store results

--- a/lib/jit/generation/reduce_1d.cpp
+++ b/lib/jit/generation/reduce_1d.cpp
@@ -143,6 +143,7 @@ std::string reduce_1d::generate_impl(std::string const & suffix, expression_tree
       stream << rd->process("#scalartype #name_acc = " + neutral_element(rd->op(), backend, "#scalartype") + ";") << std::endl;
     }
   }
+  stream << tools::join(negative_inc_process(device, symbols, tree), "  ") << std::endl;
   element_wise_loop_1D(stream, vwidth_, "i", "N", "$GLOBAL_IDX_0", "$GLOBAL_SIZE_0", [&](unsigned int vwidth)
   {
     std::string dtype = append_width("#scalartype",vwidth);
@@ -195,6 +196,7 @@ std::string reduce_1d::generate_impl(std::string const & suffix, expression_tree
   stream << "{" << std::endl;
   stream.inc_tab();
   unroll_tmp();
+  stream << tools::join(negative_inc_process(device, symbols, tree), "  ") << std::endl;
   //Declarations
   stream << "unsigned int lid = $LOCAL_IDX_0;" << std::endl;
   stream << "unsigned int lsize = $LOCAL_SIZE_0;" << std::endl;
@@ -210,7 +212,7 @@ std::string reduce_1d::generate_impl(std::string const & suffix, expression_tree
     else
     {
       stream << rd->process("$LOCAL #scalartype #name_buf[" + tools::to_string(ls0_) + "];") << std::endl;
-      stream << rd->process("#scalartype #name_acc = " + neutral_element(rd->op(), backend, "#scalartype") + ";");
+      stream << rd->process("#scalartype #name_acc = " + neutral_element(rd->op(), backend, "#scalartype") + ";");      
     }
   }
   //Private reduction

--- a/lib/jit/generation/reduce_2d.cpp
+++ b/lib/jit/generation/reduce_2d.cpp
@@ -114,6 +114,7 @@ std::string reduce_2d::generate_impl(std::string const & suffix, expression_tree
   std::ostringstream upper;
   upper << "(M +" << ls1_ - 1 << ")/" << ls1_ << "*" << ls1_;
 
+  stream << tools::join(reduce_2d_negative_inc_process(device, symbols, tree), "  ") << std::endl;
   element_wise_loop_1D(stream, (reduction_type_==REDUCE_ROWS)?1:1, "r", upper.str(), "$GLOBAL_IDX_1", "$GLOBAL_SIZE_1", [&](unsigned int cwidth)
   {
   //Declare Buffers
@@ -212,6 +213,7 @@ std::string reduce_2d::generate_impl(std::string const & suffix, expression_tree
   stream << "{" << std::endl;
   stream.inc_tab();
   unroll_tmp();
+  stream << tools::join(reduce_2d_negative_inc_process(device, symbols, tree), "  ") << std::endl;
   for (symbolic::reduce_2d* rd : reductions)
     stream << rd->process("$LOCAL #scalartype #name_buf[" + to_string(ls1_*ldls) + "];") << std::endl;
   stream << "for($SIZE_T r = $GLOBAL_IDX_1; r < (M +" << ls1_ - 1 << ")/" << ls1_ << "*" << ls1_ << "; r += " << GlobalSize1(backend) << "){" << std::endl;
@@ -265,7 +267,7 @@ std::string reduce_2d::generate_impl(std::string const & suffix, expression_tree
   stream << "}" << std::endl;
   }
 
-//  std::cout << stream.str() << std::endl;
+ // std::cout << stream.str() << std::endl;
   return stream.str();
 }
 

--- a/lib/jit/generation/tools/loop.hpp
+++ b/lib/jit/generation/tools/loop.hpp
@@ -38,7 +38,7 @@ inline void element_wise_loop_1D(kernel_generation_stream & stream, unsigned int
   std::string init = domain_id + "*" + svwidth;
   std::string lbound = bound + "/" + svwidth + "*" + svwidth;
   std::string inc = domain_size + "*" + svwidth;
-  stream << "for(unsigned int " << i << " = " << init << "; " << i << " < " << lbound << "; " << i << " += " << inc << ")" << std::endl;
+  stream << "for(int " << i << " = " << init << "; " << i << " < " << lbound << "; " << i << " += " << inc << ")" << std::endl;
   stream << "{" << std::endl;
   stream.inc_tab();
   generate_body(vwidth);
@@ -47,7 +47,7 @@ inline void element_wise_loop_1D(kernel_generation_stream & stream, unsigned int
 
   if (vwidth>1)
   {
-    stream << "for(unsigned int " << i << " = " << lbound << " + " << domain_id << "; " << i << " < " << bound << "; " << i << " += " + domain_size + ")" << std::endl;
+    stream << "for(int " << i << " = " << lbound << " + " << domain_id << "; " << i << " < " << bound << "; " << i << " += " + domain_size + ")" << std::endl;
     stream << "{" << std::endl;
     stream.inc_tab();
     generate_body(1);

--- a/lib/jit/syntax/engine/object.cpp
+++ b/lib/jit/syntax/engine/object.cpp
@@ -253,7 +253,10 @@ buffer::buffer(driver::Context const & context, std::string const & scalartype, 
     macros_.insert(make_broadcast(shape));
 
   add_base("buffer");
-  add_load(strides[0]==1 && shape[0]>1);
+//  add_load(strides[0]==1 && shape[0]>1);
+// stride==1 would result in "vloadn"'s use in kernel,if a kernel is generated with stride==1,
+// it can't run samples whose stride<0,so vloadn can't be used in kernels.
+  add_load(false);
 }
 
 //


### PR DESCRIPTION
Hi @ptillet 
We used clBLAS test suite to test the functional correctness of current ISAAC code and found that there are two points that ISAAC blas code didn't align with blas api standard.
1, negeative inc for vector; 2, clblasConjTrans on parameters.

This patch supported negative inc for vector and clblasConjTrans, and can pass all the clblas correctness test.