### PR TITLE
Fix the bug of vector subscript out of range

### DIFF
--- a/lib/array.cpp
+++ b/lib/array.cpp
@@ -862,7 +862,7 @@ expression_tree dot(LTYPE const & x, RTYPE const & y)\
     throw semantic_error("matrices are not aligned");\
   std::vector<int_t> shapedata(std::max<size_t>(1,xs.size()-1 + ys.size()-1));\
   for(size_t i = 0 ; i < shapedata.size() ; ++i){\
-    if(i < xs.size() - 1) shapedata[i] = xs[i];\
+    if(i <= xs.size() - 1) shapedata[i] = xs[i];\
     else shapedata[i] = ys[i - xs.size() + 2];\
   }\
   tuple rshape(shapedata);\


### PR DESCRIPTION
When running the SDOTFULL test case of test-blas-1, the vector size is 1, therefore the index of ys should be 0. The index, however, is 1, which is out of the range of the vector. The reason is that the program goes into the else branch instead of if branch. This modifies fixes this problem.